### PR TITLE
ascii colors in results make autotest think it's not failing, when it actually is.

### DIFF
--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -494,7 +494,8 @@ class Autotest
   # Check results for failures, set the "bar" to red or green, and if
   # there are failures record this.
 
-  def handle_results results
+  def handle_results results 
+    results = results.gsub(/\e\[(\d+)m/, '') # strip ascii color
     failed = results.scan self.failed_results_re
     completed = results[self.completed_re]
 

--- a/test/test_autotest.rb
+++ b/test/test_autotest.rb
@@ -285,6 +285,23 @@ Finished in 0.001655 seconds.
     exp = { "tests" => 12, "assertions" => 18, "failures" => 0, "errors" => 0 }
     assert_equal exp, @a.latest_results
 
+  #when colours are in the error message
+     color_error = "
+      1) \e[31mFailure:\e[0m
+    test_fail1(#{@test_class}) [#{@test}:59]:
+      2) \e[31mFailure:\e[0m
+    test_fail2(#{@test_class}) [#{@test}:60]:
+      3) \e[31mError:\e[0m
+    test_error1(#{@test_class}):
+      3) \e[31mError:\e[0m
+    test_error2(#{@test_class}):
+
+    12 tests, 18 assertions, 2 failures, 2 errors
+    "
+    @a.handle_results(color_error)
+    assert @a.tainted
+
+
     s2 = "
   1) Failure:
 test_fail1(#{@test_class}) [#{@test}:59]:


### PR DESCRIPTION
 added a test, and a fix for dealing with ascii colored error messages.
 Rspec and it's like really like to mix in ascii colors into their error messages.
 These Ascii colors mess with the regexi, which in turn end up in incorrect passes being thrown.
 This should fix that.. test and patch included.
