### PR TITLE
Replaced deprecated Gem API used for RSpec detection

### DIFF
--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -223,7 +223,7 @@ class Autotest
     #
     # I'm removing this code once a sane rspec goes out.
 
-    hacky_discovery = Gem.source_index.gems.any? { |n,_| n =~ /^rspec/ }
+    hacky_discovery = Gem::Specification.any? { |s| s.name =~ /^rspec/ }
     $: << '.' if hacky_discovery
 
     Gem.find_files("autotest/discover").each do |f|


### PR DESCRIPTION
Gem 1.8 has deprecated Gem.source_index which is used by autotest for detecting rspec. 

This change replaces the deprecated function call with what I believe should be equivalent.

Hope this helps.
