### PR TITLE
The --rc option for autotest isn't working properly

### DIFF
--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -118,7 +118,7 @@ class Autotest
       end
 
       opts.on("-r", "--rc CONF", String, "Override path to config file") do |o|
-        options[:rc] = o
+        options[:rc] = Array(o)
       end
 
       opts.on("-s", "--style STYLE", String,

--- a/test/test_autotest.rb
+++ b/test/test_autotest.rb
@@ -24,6 +24,10 @@ class Autotest
   def self.clear_hooks
     HOOKS.clear
   end
+
+  def self.reset_options
+    @@options = {}
+  end
 end
 
 class TestAutotest < MiniTest::Unit::TestCase
@@ -463,6 +467,17 @@ test_error2(#{@test_class}):
 
     f = { @test => [], "test/test_fooby.rb" => %w(first second) }
     assert_match @a.testlib, @a.make_test_cmd(f)
+  end
+
+  def test_runner_accepts_rc_options
+    begin
+      Autotest.parse_options(['--rc', 'autotest_rc'])
+      Autotest.new
+    rescue
+      deny $!, "It should not throw #{$!.message}"
+    ensure
+      Autotest.reset_options
+    end
   end
 
   def util_exceptions


### PR DESCRIPTION
It appears that the `--rc` option for autotest isn't working properly, and is resulting in a `NoMethodError`.  This pull request fixes that issue (and includes a unit test).

The issue appears to be that the initializer is expecting an `Array` object _(on line 310 or thereabouts)_, but is instead  getting a `String` instance when the `-r/--rc` option is used when invoking the autotest executable).

The following stacktrace illustrates the issue:

```
~ $ autotest --rc autotest.rc
/Users/pvandenb/.rvm/gems/ruby-1.9.2-p180/gems/ZenTest-4.5.0/lib/autotest.rb:310:in `initialize': undefined method `each' for "autotest.rc":String (NoMethodError)
    from /Users/pvandenb/.rvm/gems/ruby-1.9.2-p180/gems/ZenTest-4.5.0/lib/autotest.rb:241:in `new'
    from /Users/pvandenb/.rvm/gems/ruby-1.9.2-p180/gems/ZenTest-4.5.0/lib/autotest.rb:241:in `run'
    from /Users/pvandenb/.rvm/gems/ruby-1.9.2-p180/gems/ZenTest-4.5.0/bin/autotest:6:in `<top (required)>'
    from /Users/pvandenb/.rvm/gems/ruby-1.9.2-p180/bin/autotest:19:in `load'
    from /Users/pvandenb/.rvm/gems/ruby-1.9.2-p180/bin/autotest:19:in `<main>'
```
