### PR TITLE
Support for all rubygems versions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,8 @@ Hoe.spec "ZenTest" do
   developer 'Ryan Davis', 'ryand-ruby@zenspider.com'
   developer 'Eric Hodel', 'drbrain@segment7.net'
 
-  require_rubygems_version "~> 1.8"
+  dependency "rdoc", "~> 3", :development
+  dependency "minitest", "~> 2", :development
 end
 
 desc "run autotest on itself"

--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -225,8 +225,12 @@ class Autotest
     # documented in multiple books.
     #
     # I'm removing this code once a sane rspec goes out.
-
-    hacky_discovery = Gem::Specification.any? { |s| s.name =~ /^rspec/ }
+    
+    hacky_discovery = case Gem::VERSION.to_f < "1.8".to_f
+    when true then Gem.source_index.gems.any? { |n,_| n =~ /^rspec/ }
+    else Gem::Specification.any? { |s| s.name =~ /^rspec/ }
+    end
+      
     $: << '.' if hacky_discovery
 
     Gem.find_files("autotest/discover").each do |f|


### PR DESCRIPTION
Added regression support for rubygems <1.8. 

Removed rubygems version require from hoe. 

Added rdoc and minitest development dependencies to hoe

Note: Its tough to write tests for... but I simply made another rvm gemset on ruby 1.8.7, rubygems version: 1.4.2 and the tests all passed.  (had to install rdoc and minitest gems, hence the development dependencies)

Perhaps those development dependencies need to be runtime?
