### PR TITLE
autotest doesn't require testlib when running specific test methods

### DIFF
--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -616,7 +616,7 @@ class Autotest
 
     partial.each do |klass, methods|
       regexp = Regexp.union(*methods).source
-      cmds << "#{ruby_cmd} #{klass} -n \"/^(#{regexp})$/\"#{diff}"
+      cmds << "#{ruby_cmd} -r#{testlib} #{klass} -n \"/^(#{regexp})$/\"#{diff}"
     end
 
     cmds.join "#{SEP} "

--- a/test/test_autotest.rb
+++ b/test/test_autotest.rb
@@ -396,7 +396,7 @@ test_error2(#{@test_class}):
 
     expected =
       [ "#{pre} -e \"%w[test/unit #{@test}]#{req}",
-        "#{pre} test/test_fooby.rb -n \"/^(test_something1|test_something2)$/\""
+        "#{pre} -rtest/unit test/test_fooby.rb -n \"/^(test_something1|test_something2)$/\""
       ].join("; ")
 
     result = @a.make_test_cmd f
@@ -415,7 +415,7 @@ test_error2(#{@test_class}):
     post = "| unit_diff -u"
 
     expected = [ "#{pre} -e \"%w[test/unit #{@test}]#{req} #{post}",
-                 "#{pre} test/test_fooby.rb -n \"/^(test_something1|test_something2)$/\" #{post}" ].join("; ")
+                 "#{pre} -rtest/unit test/test_fooby.rb -n \"/^(test_something1|test_something2)$/\" #{post}" ].join("; ")
 
     result = @a.make_test_cmd f
     assert_equal expected, result


### PR DESCRIPTION
This causes problems if you're relying on autotest exclusively to load your test lib. I guess it's debatable whether it's a good idea to do that in the first place, but it seems like the behavior should be consistent between full and partial runs.
