### PR TITLE
Use failed to determine red/green hook.

### DIFF
--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -573,7 +573,7 @@ class Autotest
       self.latest_results = Hash[*completed.flatten]
       self.files_to_test  = consolidate_failures failed
 
-      color = self.files_to_test.empty? ? :green : :red
+      color = failed.empty? ? :green : :red
       hook color unless $TESTING
     else
       self.latest_results = nil


### PR DESCRIPTION
files_to_test can be empty if class mapping is off, so green hook was firing even though tests didn't pass. There might be a better way to do this.
