### PR TITLE
Require rubygems 1.8 or higher, upper limit 2.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ Hoe.spec "ZenTest" do
   developer 'Ryan Davis', 'ryand-ruby@zenspider.com'
   developer 'Eric Hodel', 'drbrain@segment7.net'
 
-  require_rubygems_version ">= 1.8"
+  require_rubygems_version Proc.new { [">= 1.8", "< 2.1"] }
 end
 
 desc "run autotest on itself"


### PR DESCRIPTION
Current rubygems preview version is 2.0.0.preview2.1
https://rubygems.org/gems/rubygems-update/versions/2.0.0.preview2.1
