### PR TITLE
Expand required rubygems version to be < 2.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ Hoe.spec "ZenTest" do
   developer 'Ryan Davis', 'ryand-ruby@zenspider.com'
   developer 'Eric Hodel', 'drbrain@segment7.net'
 
-  require_rubygems_version [">= 1.8", "< 2.2"]
+  require_rubygems_version [">= 1.8", "< 2.3"]
 end
 
 desc "run autotest on itself"


### PR DESCRIPTION
When trying to `gem install ZenTest` with RubyGems 2.2 I get the following error:

```
ZenTest requires RubyGems version < 2.2, >= 1.8. Try 'gem update --system' to update RubyGems itself.
```

This patch will fix it.
