### PR TITLE
Fix: let autotest trigger on new files after the first run

### DIFF
--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -290,8 +290,7 @@ class Autotest
     self.extra_files       = []
     self.failed_results_re = /^\s*\d+\) (?:Failure|Error):\n(.*?)(?: [\(\[](.*?)[\)\]])?:$/
     self.files_to_test     = new_hash_of_arrays
-    self.find_order        = []
-    self.known_files       = nil
+    reset_find_order
     self.libs              = %w[. lib test].join(File::PATH_SEPARATOR)
     self.order             = :random
     self.output            = $stderr
@@ -538,7 +537,7 @@ class Autotest
   def find_files
     result = {}
     targets = self.find_directories + self.extra_files
-    self.find_order.clear
+    reset_find_order
 
     targets.each do |target|
       order = []
@@ -695,15 +694,19 @@ class Autotest
 
   def reset
     self.files_to_test.clear
-    self.find_order.clear
+    reset_find_order
 
     self.interrupted   = false
-    self.known_files   = nil
     self.last_mtime    = T0
     self.tainted       = false
     self.wants_to_quit = false
 
     hook :reset
+  end
+
+  def reset_find_order
+    self.find_order = []
+    self.known_files = nil
   end
 
   ##


### PR DESCRIPTION
autotest would not detect any new file after the first run; very annoying when doing coding katas, still annoying on other projects.

Writing a test would be hard, since I'd have to either mock Find.find, or actually create files. Trying to extract Find.find (so I could test the remainder, but also replace it with e.g. rbinotify) is even harder, since a lot more happens than just finding files:
- Filtering certain patterns (what is isolate? why RCS? why not git? Perhaps a $HOME/.autotest could harbour add_exception statements for these kind of things?)
- partially sorting file names (targets are not sorted; probably intentional) and storing them in a field (side-effect, if you ask me).
- returning mtimes (I'd expect the files by themselves)

I would change a lot if I were to refactor that code. Which is not worth it for the bugfix by itself; but also not sensible without discussing beforehand. So. No test.

Hope you still merge.

Bye,
Kero.
