### PR TITLE
fix autotest SystemStackError with very large numbers of files 

### DIFF
--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -622,7 +622,8 @@ class Autotest
 
   def known_files
     unless @known_files then
-      @known_files = Hash[*find_order.map { |f| [f, true] }.flatten]
+      @known_files = {}
+      find_order.each {|f| @known_files[f] = true }
     end
     @known_files
   end


### PR DESCRIPTION
fix autotest failure with very large numbers of files (e.g. git repo with lots of objects). 
see https://bugs.ruby-lang.org/issues/4040 for the origin of this bug (which is really an unfixed ruby bug)
