### PR TITLE
Loosen rubygems requirement

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ Hoe.spec "ZenTest" do
   developer 'Ryan Davis', 'ryand-ruby@zenspider.com'
   developer 'Eric Hodel', 'drbrain@segment7.net'
 
-  require_rubygems_version [">= 1.8", "< 3.0"]
+  require_rubygems_version ">= 1.8"
 end
 
 desc "run autotest on itself"


### PR DESCRIPTION
Ruby 2.6.0 ships with rubygems@3.0.1, which causes installation to fail for me. For example, my app depends on `fuzzy-string-match`, which depends on `RubyInline`, which depends on ZenTest.

AFAICT, the gem works fine under rubygems 3. Please forgive my ignorance if I have this wrong, though, as I don't know this gem or its constraints well. Just trying to troubleshoot my 2.6.0 install