### PR TITLE
Support classes that override the `name` method

### DIFF
--- a/lib/zentest.rb
+++ b/lib/zentest.rb
@@ -6,11 +6,11 @@ end
 $stdlib = {}
 if ObjectSpace.respond_to?(:loaded_classes, true) then
   ObjectSpace.loaded_classes(true).each do |m|
-    $stdlib[m.name] = true if m.respond_to? :name
+    $stdlib[Module.instance_method(:name).bind(m).call] = true
   end
 else
   ObjectSpace.each_object(Module) do |m|
-    $stdlib[m.name] = true if m.respond_to? :name
+    $stdlib[Module.instance_method(:name).bind(m).call] = true
   end
 end
 


### PR DESCRIPTION
I was working with a class that overrides `name` (that doesn't seem like a good idea but it's what I've got) and of course the line that calls `m.name` fails miserably. This change calls the original `Module.name` even in a subclass that overrides that method.

I'm not sure how to test this since there's no CI enabled but would appreciate a pointer.